### PR TITLE
add prodecures files

### DIFF
--- a/scripts/embassy.ts
+++ b/scripts/embassy.ts
@@ -1,1 +1,5 @@
+export { setConfig } from "./procedures/setConfig.ts";
 export { dependencies } from "./procedures/dependencies.ts";
+export { properties } from "./procedures/properties.ts";
+export { getConfig } from "./procedures/getConfig.ts";
+export { migration } from "./procedures/migrations.ts";

--- a/scripts/procedures/getConfig.ts
+++ b/scripts/procedures/getConfig.ts
@@ -1,0 +1,5 @@
+// To utilize the default config system built, this file is required. It defines the *structure* of the configuration file. These structured options display as changeable UI elements within the "Config" section of the service details page in the StartOS UI.
+
+import { compat, types as T } from "../deps.ts";
+
+export const getConfig: T.ExpectedExports.getConfig = compat.getConfig({});

--- a/scripts/procedures/migrations.ts
+++ b/scripts/procedures/migrations.ts
@@ -1,0 +1,4 @@
+import { compat, types as T } from "../deps.ts";
+
+export const migration: T.ExpectedExports.migration = compat.migrations.
+    fromMapping({}, "2.1.1");

--- a/scripts/procedures/properties.ts
+++ b/scripts/procedures/properties.ts
@@ -1,0 +1,3 @@
+import { compat, types as T } from "../deps.ts";
+
+export const properties: T.ExpectedExports.properties = compat.properties;

--- a/scripts/procedures/setConfig.ts
+++ b/scripts/procedures/setConfig.ts
@@ -1,0 +1,5 @@
+// This is where any configuration rules related to the configuration would go. These ensure that the user can only create a valid config.
+
+import { compat, } from "../deps.ts";
+
+export const setConfig = compat.setConfig;


### PR DESCRIPTION
`migrations.ts` will be required for users to update from Clams Remote 2.1.1 to subsequent versions. The other files aren't strictly necessary for the package to build, but should be included as a best practice.